### PR TITLE
Fix Era5AutoEncoder

### DIFF
--- a/ml_examples/era5_autoencoder/era5_autoencoder_train.ipynb
+++ b/ml_examples/era5_autoencoder/era5_autoencoder_train.ipynb
@@ -1511,8 +1511,8 @@
     "                               ),\n",
     "                torch.nn.ReLU(),\n",
     "                torch.nn.Flatten(),\n",
-    "                # torch.nn.Linear(self._prelatent_size, self._latent_size),\n",
-    "                # torch.nn.ReLU(),\n",
+    "                torch.nn.Linear(self._prelatent_size, self._latent_size),\n",
+    "                torch.nn.ReLU(),\n",
     "            )\n",
     "        return encoder\n",
     "\n",
@@ -1520,6 +1520,8 @@
     "        \"\"\"\n",
     "        \"\"\"\n",
     "        decoder = torch.nn.Sequential(\n",
+    "            torch.nn.Linear(self._latent_size, self._prelatent_size),\n",
+    "            torch.nn.Unflatten(dim=1, unflattened_size=self._latent_array_dims[1:]),\n",
     "            torch.nn.ConvTranspose2d(in_channels=32, out_channels=16, kernel_size=2,stride=2),\n",
     "            torch.nn.ReLU(),\n",
     "            torch.nn.ConvTranspose2d(in_channels=16, out_channels=self.num_channels, kernel_size=2,stride=2),\n",
@@ -1528,12 +1530,15 @@
     "        )\n",
     "        return decoder\n",
     "    def forward(self, x):\n",
+    "        # Convert to 4D batch of size 1 if input is single datapoint\n",
+    "        if x.ndim == 3:\n",
+    "            x = x.unsqueeze(0)\n",
     "\n",
     "        # Get latent representation\n",
     "        latent = self._encoder(x)\n",
     "\n",
     "        # Reconstruct input\n",
-    "        reconstructed = self._decoder(latent.view(self._latent_array_dims))\n",
+    "        reconstructed = self._decoder(latent)\n",
     "        # reconstructed = self._decoder(latent)\n",
     "\n",
     "        return reconstructed"
@@ -1601,28 +1606,6 @@
    "source": [
     "# check a full forward pass\n",
     "ae_model.forward(wb_val_ds[2].to(device)).shape"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 33,
-   "id": "dd626e2a-9fb0-4fa3-861a-1b2135683703",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "torch.Size([32, 128])"
-      ]
-     },
-     "execution_count": 33,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "# pass through only encoder to see what the shape of the latent space is\n",
-    "ae_model._encoder(wb_val_ds[2].to(device)).shape"
    ]
   },
   {


### PR DESCRIPTION
Fix Era5AutoEncoder - convert input to 4D; Remove unnecessary encoder cell