### PR TITLE
Fix dead neptune.ai blog link in cloud base height PyTorch notebook

### DIFF
--- a/challenges/2021_cloud_base_height/03_pytorch_train.ipynb
+++ b/challenges/2021_cloud_base_height/03_pytorch_train.ipynb
@@ -1035,7 +1035,7 @@
     "In this phase of the model pipeline it is important to make many iterations to ensure that the model is well understood. It is helpful to print the dimensions of layers at each step of the foward pass, to verify the model behaves as expected, and monitor loss for reasonable learning\n",
     "\n",
     "- Are there any dead weights? https://towardsdatascience.com/neural-network-the-dead-neuron-eaa92e575748\n",
-    "- Does the learning rate cause the gradient to explode https://neptune.ai/blog/vanishing-and-exploding-gradients-debugging-monitoring-fixing\n",
+    "- Does the learning rate cause the gradient to explode https://web.archive.org/web/20250109100349/https://neptune.ai/blog/vanishing-and-exploding-gradients-debugging-monitoring-fixing\n",
     "\n",
     "These resources may help in debugging\n",
     "\n",


### PR DESCRIPTION
neptune.ai was acquired by OpenAI in December 2025 and the entire blog now 308-redirects to a press-release page, so the neptune.ai/blog link(s) below no longer lead to the referenced article(s).

This PR fixes 1 dead link in `challenges/2021_cloud_base_height/03_pytorch_train.ipynb`, pointing the *vanishing/exploding gradients* reference to the Wayback Machine snapshot of the original article, pinned to the last working (HTTP 200) capture before the redirect took effect.